### PR TITLE
Refactor Notepad.jsx and make route RESTful

### DIFF
--- a/client/src/components/Notepad.jsx
+++ b/client/src/components/Notepad.jsx
@@ -1,60 +1,51 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState } from 'react';
 import './assets/App.scss';
 
 function Notepad({ username, setTotalNotes, noteContent }) {
-  const titleRef = useRef(null)
-  const noteRef = useRef(null)
-  
-  const useInput = init => {
-    const [ value, setValue ] = useState(init);
-    const onChange = e => {
-      setValue(e.target.value);
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+
+  const saveNote = async () => {
+    try {
+      // Create a new note
+      await fetch('/notes', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          title,
+          content,
+          username,
+        }),
+      });
+      console.log('Created a new note.');
+    } catch (err) {
+      console.error(err);
     }
-    return [ value, onChange ];
-  }
-  const [ title, setNoteTitle ] = useInput('');
-  const [ content, setNoteBody ] = useInput('');
-
-  const saveNote = () => {
-    
-    const body = {
-      title: titleRef.current.value,
-      content: noteRef.current.value,
-      username
-    }
-
-    console.log(body) // - > {title: "", content: "", username: "hello"}
-
-    fetch('/notes/create', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(body)
-    })
-      .then(resp => resp.json())
-      .then((data) => {
-        console.log(data); // -> note and notes
-        setTotalNotes(data.notes);
-        // window.location.reload();
-      })
-      // .then(() => {
-      //   props.history.push('/');
-      // })
-      .catch(err => console.log('saveNote fetch /notes/create: ERROR: ', err));
-  }
+  };
 
   return (
     <div className="note">
-      {/* Issues with scaling textarea to page */}
-
-      {/* <input type='text' placeholder='Note Title' id='noteTitle' value={title} required></input> */}
-      {/* <textarea type='text' placeholder='Jot some notes!' id='noteBody' rows='44' cols='54' value={content} required></textarea> */}
-      <input type='text' placeholder='Note Title' ref={titleRef} id='noteTitle' defaultValue={ noteContent.title } required></input>
-      <textarea type='text' placeholder='Jot some notes!' ref={noteRef} id='noteBody' rows='44' cols='54' defaultValue={noteContent.content} required></textarea>
-
-
-      <button onClick={() => saveNote()}>save</button>
+      <input
+        id="noteTitle"
+        type="text"
+        placeholder="Note Title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        required
+      ></input>
+      <textarea
+        id="noteBody"
+        type="text"
+        placeholder="Jot some notes!"
+        rows="44"
+        cols="54"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        required
+      ></textarea>
+      <button onClick={saveNote}>save</button>
     </div>
   );
 }

--- a/server/routes/notesRouter.js
+++ b/server/routes/notesRouter.js
@@ -2,17 +2,16 @@ const express = require('express');
 
 const router = express.Router();
 const notesController = require('../controllers/notesController');
-const userController = require('../controllers/userController')
+const userController = require('../controllers/userController');
 
-// Route to create and add a new note to our user
-
-router.post('/create', notesController.createNote, notesController.getUserNotes, (req, res) => {
+// Create a new note
+router.post('/', notesController.createNote, notesController.getUserNotes, (req, res) => {
   res.status(200).json(res.locals);
 });
 
 router.post('/display', notesController.getNote, (req, res) => {
   res.status(200).json(res.locals.note);
-})
+});
 
 router.patch('/update', notesController.updateNote, (req, res) => {
   res.status(200).json(res.locals.update);
@@ -23,5 +22,3 @@ router.delete('/delete', notesController.deleteNote, (req, res) => {
 });
 
 module.exports = router;
-
-


### PR DESCRIPTION
Notepad.jsx now uses `useState` hook instead of `useRef` and `useInput`.

Route to create a new note has been changed from `POST /notes/create/` to `POST /notes` to follow REST convention.