### PR TITLE
:sparkles: Add Husky

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no --commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# Exit if in production
+# More specifically, most Continuous Integration Servers set a CI environment variable. 
+# The following detects if this script is running in a CI, early exit 
+[ -n "$CI" ] && exit 0
+
+# Grab current name of branch
+LOCAL_BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
+
+# Branch name regex match
+VALID_BRANCH_REGEX='^((bug|docs|fix|feat|merge|test|wip)\/[a-zA-Z0-9\-]+)$'
+
+ERROR_MSG="\n${Red}There is something wrong with your branch name.\nBranch names must adhere to this contract:${Color_Off}\n\n${Yellow}$VALID_BRANCH_REGEX\n\n${Red}Due to this conflict, your commit has been rejected. Please rename your branch to a valid name and try again.${Color_Off}"
+
+FIX_MSG="${Yellow}You can rename your current working branch with:\ngit branch --move \$OLD_NAME \$NEW_NAME\ngit push --set-upstream \$REMOTE \$NEW_NAME\ngit branch -a\n\nAnd then remove the old branch on remote:\ngit push \$REMOTE --delete \$OLD_NAME\n${Color_Off}"
+
+# Rejects commit if current branch name does not match regex pattern
+if [[ ! $LOCAL_BRANCH_NAME =~ $VALID_BRANCH_REGEX ]]; then
+    # Print error
+    echo "$ERROR_MSG\n\n"
+    # Optional: Error fix suggestion
+    echo "$FIX_MSG"
+    # Abort commit
+    exit 1
+fi
+
+exit 0

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm test # All tests must pass before allowing commit

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
         "html-webpack-plugin": "^5.5.1",
+        "husky": "^8.0.0",
         "nodemon": "^2.0.22",
         "prettier": "^2.8.8",
         "sass": "^1.62.1",
@@ -4612,6 +4613,21 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "start": "webpack-dev-server --mode development --open --hot",
     "build": "webpack --mode production",
-    "dev": "webpack-dev-server --mode development --open --hot & nodemon server/server.js"
+    "dev": "webpack-dev-server --mode development --open --hot & nodemon server/server.js",
+    "test": "echo 'Please add tests'",
+    "prepare": "husky install"
   },
   "keywords": [],
   "author": "",
@@ -30,6 +32,7 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",
     "html-webpack-plugin": "^5.5.1",
+    "husky": "^8.0.0",
     "nodemon": "^2.0.22",
     "prettier": "^2.8.8",
     "sass": "^1.62.1",


### PR DESCRIPTION
# Adds Husky for Git Hooks support

## Current Features:

### Pre-commit Branch name linting

- Skips pre-commit tests if `CI` env variable is set.

```sh
[ -n "$CI" ] && exit 0
```

- Branch names must now adhere to the following regex pattern:

```js
/^((bug|docs|fix|feat|merge|test|wip)\/[a-zA-Z0-9\-]+)$/
```

### Pre-Push Automated Testing

- Adds placeholders for future implementations of testing scripts. Please add test script to `package.json.scripts.test` for immediate pre-push support. If adding additional scripts, ensure that those scripts are added to Husky `pre-push` shell script.